### PR TITLE
Refactor: extract reschedule logic into standalone module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.testing.pytestArgs": [
+        "src"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:poetry",
+            "packageManager": "ms-python.python:poetry"
+        }
+    ]
+}

--- a/src/todoistScheduler/reschedule.py
+++ b/src/todoistScheduler/reschedule.py
@@ -1,0 +1,45 @@
+import re
+import logging
+from datetime import date, datetime
+
+from todoist_api_python.api import TodoistAPI
+from todoist_api_python.models import Task
+
+
+def compute_due_string(task: Task, day: date) -> str | None:
+    """Compute the due string needed to reschedule a task to a new day.
+
+    Returns None if the task is already scheduled for that day.
+    Preserves time for datetime tasks and recurrence patterns for recurring tasks.
+    """
+    if task.due and task.due.date == day.strftime('%Y-%m-%d'):
+        return None
+
+    if task.due and task.due.datetime:
+        # This is a datetime object, so we can use strftime
+        time_str = datetime.fromisoformat(task.due.datetime).strftime('%H:%M')
+        due_date_string = f"{day.strftime('%Y-%m-%d')} {time_str}"
+    else:
+        # This is just a date
+        due_date_string = day.strftime('%Y-%m-%d')
+
+    if task.due and task.due.is_recurring:
+        # Preserve original due date string for recurring tasks
+        original_due = re.sub(r'\s*starting on.*', '', task.due.string)
+        due_date_string = f"{original_due} starting on {due_date_string}"
+
+    return due_date_string
+
+
+def reschedule_task(api: TodoistAPI, task: Task, day: date) -> None:
+    """Reschedule a task to a new date via the Todoist API."""
+    due_string = compute_due_string(task, day)
+    if due_string is None:
+        return
+
+    logging.info(f"Sending the task '{task.content}' to {day}")
+    logging.debug("updating task_id %s with: %s", task.id, due_string)
+
+    is_success = api.update_task(task_id=task.id, due_string=due_string)
+    if not is_success:
+        raise Exception(f"Failed to reschedule task: {task.content}")

--- a/src/todoistScheduler/scheduler.py
+++ b/src/todoistScheduler/scheduler.py
@@ -1,5 +1,5 @@
 import re
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 import logging
 from typing import List, Optional, Tuple, TypeVar
 
@@ -36,7 +36,14 @@ class Scheduler:
 
         logging.info(f"Sending the task '{task.content}' to {day}")
 
-        due_date_string = day.strftime('%Y-%m-%d')
+        if task.due and task.due.datetime:
+            # This is a datetime object, so we can use strftime
+            time_str = datetime.fromisoformat(task.due.datetime).strftime('%H:%M')
+            due_date_string = f"{day.strftime('%Y-%m-%d')} {time_str}"
+        else:
+            # This is just a date
+            due_date_string = day.strftime('%Y-%m-%d')
+
         if task.due and task.due.is_recurring:
             # Preserve original due date string for recurring tasks
             original_due = re.sub(r'\s*starting on.*', '', task.due.string)

--- a/src/todoistScheduler/scheduler.py
+++ b/src/todoistScheduler/scheduler.py
@@ -1,10 +1,11 @@
-import re
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 import logging
 from typing import List, Optional, Tuple, TypeVar
 
 from todoist_api_python.api import TodoistAPI
 from todoist_api_python.models import Task
+
+from todoistScheduler.reschedule import reschedule_task
 
 T = TypeVar('T')
 
@@ -31,29 +32,7 @@ class Scheduler:
 
     def _reschedule_to(self, task: Task, day: date) -> None:
         """Reschedules a task to a new date."""
-        if task.due and task.due.date == day.strftime('%Y-%m-%d'):
-            return
-
-        logging.info(f"Sending the task '{task.content}' to {day}")
-
-        if task.due and task.due.datetime:
-            # This is a datetime object, so we can use strftime
-            time_str = datetime.fromisoformat(task.due.datetime).strftime('%H:%M')
-            due_date_string = f"{day.strftime('%Y-%m-%d')} {time_str}"
-        else:
-            # This is just a date
-            due_date_string = day.strftime('%Y-%m-%d')
-
-        if task.due and task.due.is_recurring:
-            # Preserve original due date string for recurring tasks
-            original_due = re.sub(r'\s*starting on.*', '', task.due.string)
-            due_date_string = f"{original_due} starting on {due_date_string}"
-
-        logging.debug("updating task_id %s with: %s", task.id, due_date_string)
-        is_success = self.api.update_task(task_id=task.id, due_string=due_date_string)
-
-        if not is_success:
-            raise Exception(f"Failed to reschedule task: {task.content}")
+        reschedule_task(self.api, task, day)
 
     def _slice_list(self, lst: List[T], num_items: int) -> Tuple[List[T], List[T]]:
         """Slices a list into two parts at a given index."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+from todoist_api_python.models import Task, Due
+
+
+def create_task(
+    id,
+    content,
+    priority=1,
+    due_date_str=None,
+    is_recurring=False,
+    due_string=None,
+    due_datetime_str=None,
+):
+    due = None
+    if due_date_str:
+        if not due_string:
+            due_string = (
+                f"every day starting {due_date_str}"
+                if is_recurring
+                else due_date_str
+            )
+        due = Due(
+            string=due_string,
+            date=due_date_str,
+            is_recurring=is_recurring,
+            timezone=None,
+            datetime=due_datetime_str
+        )
+
+    return Task(
+        id=id,
+        content=content,
+        priority=priority,
+        due=due,
+        assignee_id=None,
+        assigner_id=None,
+        comment_count=0,
+        is_completed=False,
+        created_at='2024-01-01T12:00:00Z',
+        creator_id='1',
+        description='',
+        labels=[],
+        order=0,
+        parent_id=None,
+        project_id='1',
+        section_id=None,
+        url='',
+        sync_id=None,
+    )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,14 +8,15 @@ from todoistScheduler.scheduler import Scheduler
 # A sentinel object to detect if a keyword argument was provided
 _SENTINEL = object()
 
-def create_task(id, content, priority=1, due_date_str=None, is_recurring=False, due=_SENTINEL):
+def create_task(id, content, priority=1, due_date_str=None, is_recurring=False, due=_SENTINEL, due_string=None, due_datetime_str=None):
     if due is _SENTINEL:
         if due_date_str:
             due = Due(
-                string=f"every day starting {due_date_str}" if is_recurring else due_date_str,
+                string=due_string if due_string else (f"every day starting {due_date_str}" if is_recurring else due_date_str),
                 date=due_date_str,
                 is_recurring=is_recurring,
-                timezone=None
+                timezone=None,
+                datetime=due_datetime_str
             )
         else:
             due = None
@@ -166,6 +167,49 @@ class TestScheduling(unittest.TestCase):
         ]
         self.api.update_task.assert_has_calls(update_task_calls, any_order=True)
         self.assertEqual(self.api.update_task.call_count, 3)
+
+    def test_reschedule_preserves_time(self):
+        due_datetime_str = "2023-12-31T17:00:00Z"
+        tasks_to_add = [
+            create_task(
+                '1',
+                'Task with time',
+                priority=4,
+                due_date_str='2023-12-31',
+                is_recurring=True,
+                due_string='every week at 5pm',
+                due_datetime_str=due_datetime_str
+            )
+        ]
+        self.api.get_tasks.return_value = []
+        self.scheduler.schedule_and_push_down(tasks_to_add)
+
+        expected_due_string = f"every week at 5pm starting on {self.today.strftime('%Y-%m-%d')} 17:00"
+        self.api.update_task.assert_called_once_with(
+            task_id='1',
+            due_string=expected_due_string
+        )
+
+    def test_reschedule_non_recurring_preserves_time(self):
+        due_datetime_str = "2023-12-31T17:00:00Z"
+        tasks_to_add = [
+            create_task(
+                '1',
+                'Task with time',
+                priority=4,
+                due_date_str='2023-12-31',
+                is_recurring=False,
+                due_datetime_str=due_datetime_str
+            )
+        ]
+        self.api.get_tasks.return_value = []
+        self.scheduler.schedule_and_push_down(tasks_to_add)
+
+        expected_due_string = f"{self.today.strftime('%Y-%m-%d')} 17:00"
+        self.api.update_task.assert_called_once_with(
+            task_id='1',
+            due_string=expected_due_string
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,45 +2,8 @@ import unittest
 from unittest.mock import MagicMock, call
 from datetime import date, timedelta
 
-from todoist_api_python.models import Task, Due
 from todoistScheduler.scheduler import Scheduler
-
-# A sentinel object to detect if a keyword argument was provided
-_SENTINEL = object()
-
-def create_task(id, content, priority=1, due_date_str=None, is_recurring=False, due=_SENTINEL, due_string=None, due_datetime_str=None):
-    if due is _SENTINEL:
-        if due_date_str:
-            due = Due(
-                string=due_string if due_string else (f"every day starting {due_date_str}" if is_recurring else due_date_str),
-                date=due_date_str,
-                is_recurring=is_recurring,
-                timezone=None,
-                datetime=due_datetime_str
-            )
-        else:
-            due = None
-
-    return Task(
-        id=id,
-        content=content,
-        priority=priority,
-        due=due,
-        assignee_id=None,
-        assigner_id=None,
-        comment_count=0,
-        is_completed=False,
-        created_at='2024-01-01T12:00:00Z',
-        creator_id='1',
-        description='',
-        labels=[],
-        order=0,
-        parent_id=None,
-        project_id='1',
-        section_id=None,
-        url='',
-        sync_id=None,
-    )
+from conftest import create_task
 
 
 class TestSchedulerMethods(unittest.TestCase):
@@ -79,7 +42,7 @@ class TestSchedulerMethods(unittest.TestCase):
 
     def test_sort_due_is_none(self):
         task_with_due = create_task('with_due', 'with_due', due_date_str='2024-01-01')
-        task_without_due = create_task('without_due', 'without_due', due=None)
+        task_without_due = create_task('without_due', 'without_due')
         task_without_due.priority = 4
         lst = [task_with_due, task_without_due]
         self.scheduler._sort_tasks(lst)

--- a/tests/test_reschedule.py
+++ b/tests/test_reschedule.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import date
+
+from todoistScheduler.reschedule import compute_due_string, reschedule_task
+from conftest import create_task
+
+
+class TestComputeDueString(unittest.TestCase):
+
+    def test_already_on_target_day(self):
+        task = create_task('1', 'Task', due_date_str='2024-01-15')
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertIsNone(result)
+
+    def test_date_only(self):
+        task = create_task('1', 'Task', due_date_str='2024-01-10')
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, '2024-01-15')
+
+    def test_preserves_time(self):
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            due_datetime_str='2024-01-10T17:00:00Z',
+        )
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, '2024-01-15 17:00')
+
+    def test_recurring_date_only(self):
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every week',
+        )
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, 'every week starting on 2024-01-15')
+
+    def test_recurring_preserves_time(self):
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every week at 5pm',
+            due_datetime_str='2024-01-10T17:00:00Z'
+        )
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, 'every week at 5pm starting on 2024-01-15 17:00')
+
+    def test_recurring_strips_existing_starting_on(self):
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every week at 5pm starting on 2024-01-01 17:00',
+            due_datetime_str='2024-01-10T17:00:00Z'
+        )
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, 'every week at 5pm starting on 2024-01-15 17:00')
+
+    def test_no_due(self):
+        task = create_task('1', 'Task')
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(result, '2024-01-15')
+
+
+class TestRescheduleTask(unittest.TestCase):
+
+    def setUp(self):
+        self.api = MagicMock()
+        self.api.update_task.return_value = True
+
+    def test_calls_api(self):
+        task = create_task('1', 'Task', due_date_str='2024-01-10')
+        reschedule_task(self.api, task, date(2024, 1, 15))
+        self.api.update_task.assert_called_once_with(
+            task_id='1', due_string='2024-01-15',
+        )
+
+    def test_skips_when_already_on_day(self):
+        task = create_task('1', 'Task', due_date_str='2024-01-15')
+        reschedule_task(self.api, task, date(2024, 1, 15))
+        self.api.update_task.assert_not_called()
+
+    def test_raises_on_failure(self):
+        self.api.update_task.return_value = False
+        task = create_task('1', 'Task', due_date_str='2024-01-10')
+        with self.assertRaises(Exception):
+            reschedule_task(self.api, task, date(2024, 1, 15))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract `_reschedule_to` logic from `Scheduler` class into a new `reschedule.py` module with two standalone functions: `compute_due_string` (pure logic) and `reschedule_task` (API wrapper)
- Move shared `create_task` test helper into `conftest.py`
- Add focused unit tests for the new module in `test_reschedule.py`

## Motivation
Clean separation of the reschedule logic enables reuse by an MCP server without depending on the `Scheduler` class.

## Test plan
- [x] All 23 existing + new tests pass
- [x] `compute_due_string` tested independently for date-only, datetime, recurring, and edge cases
- [x] `reschedule_task` tested for API calls, skip-if-same-day, and error handling